### PR TITLE
Correct use of result.duration and "registration" for State documents

### DIFF
--- a/Doc/Doc.shfbproj
+++ b/Doc/Doc.shfbproj
@@ -26,7 +26,7 @@
       <Argument Key="logoAlignment" Value="left" xmlns="" />
       <Argument Key="maxVersionParts" Value="" xmlns="" />
     </TransformComponentArguments>
-    <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
+    <BuildAssemblerVerbosity>OnlyErrors</BuildAssemblerVerbosity>
     <HelpFileFormat>Website</HelpFileFormat>
     <IndentHtml>False</IndentHtml>
     <KeepLogFile>True</KeepLogFile>
@@ -49,6 +49,7 @@
     <FeedbackEMailLinkText>support%40tincanapi.com</FeedbackEMailLinkText>
     <FeedbackEMailAddress>support%40tincanapi.com</FeedbackEMailAddress>
     <CopyrightText>2014 Rustici Software</CopyrightText>
+    <MissingTags>AutoDocumentCtors, AutoDocumentDispose</MissingTags>
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
 			 the build.  The others are optional common platform types that may appear. -->

--- a/TinCan/Documents/StateDocument.cs
+++ b/TinCan/Documents/StateDocument.cs
@@ -21,6 +21,6 @@ namespace TinCan.Documents
     {
         public Activity activity { get; set; }
         public Agent agent { get; set; }
-        public Guid registration { get; set; }
+        public Nullable<Guid> registration { get; set; }
     }
 }

--- a/TinCan/RemoteLRS.cs
+++ b/TinCan/RemoteLRS.cs
@@ -552,6 +552,12 @@ namespace TinCan
             state.activity = activity;
             state.agent = agent;
 
+            if (registration != null)
+            {
+                queryParams.Add("registration", registration.ToString());
+                state.registration = registration;
+            }
+
             var resp = GetDocument("activities/state", queryParams, state);
             if (resp.status != HttpStatusCode.OK && resp.status != HttpStatusCode.NotFound)
             {
@@ -570,6 +576,10 @@ namespace TinCan
             queryParams.Add("stateId", state.id);
             queryParams.Add("activityId", state.activity.id.ToString());
             queryParams.Add("agent", state.agent.ToJSON(version));
+            if (state.registration != null)
+            {
+                queryParams.Add("registration", state.registration.ToString());
+            }
 
             return SaveDocument("activities/state", queryParams, state);
         }

--- a/TinCan/Result.cs
+++ b/TinCan/Result.cs
@@ -25,7 +25,7 @@ namespace TinCan
         public Nullable<Boolean> completion { get; set; }
         public Nullable<Boolean> success { get; set; }
         public String response { get; set; }
-        public TimeSpan duration { get; set; }
+        public Nullable<TimeSpan> duration { get; set; }
         public Score score { get; set; }
         public Extensions extensions { get; set; }
 
@@ -78,7 +78,7 @@ namespace TinCan
             }
             if (duration != null)
             {
-                result.Add("duration", XmlConvert.ToString(duration));
+                result.Add("duration", XmlConvert.ToString((TimeSpan)duration));
             }
             if (score != null)
             {

--- a/TinCan/TCAPIVersion.cs
+++ b/TinCan/TCAPIVersion.cs
@@ -23,13 +23,32 @@ namespace TinCan
         //public static readonly TCAPIVersion V102 = new TCAPIVersion("1.0.2");
         public static readonly TCAPIVersion V101 = new TCAPIVersion("1.0.1");
         public static readonly TCAPIVersion V100 = new TCAPIVersion("1.0.0");
+        public static readonly TCAPIVersion V095 = new TCAPIVersion("0.95");
+        public static readonly TCAPIVersion V090 = new TCAPIVersion("0.9");
 
         public static TCAPIVersion latest()
         {
             return V101;
         }
 
+        private static Dictionary<String, TCAPIVersion> known;
         private static Dictionary<String, TCAPIVersion> supported;
+
+        public static Dictionary<String, TCAPIVersion> GetKnown()
+        {
+            if (known != null) {
+                return known;
+            }
+
+            known = new Dictionary<String, TCAPIVersion>();
+            //known.Add("1.0.2", V102);
+            known.Add("1.0.1", V101);
+            known.Add("1.0.0", V100);
+            known.Add("0.95", V095);
+            known.Add("0.9", V090);
+
+            return known;
+        }
 
         public static Dictionary<String, TCAPIVersion> GetSupported()
         {
@@ -47,10 +66,10 @@ namespace TinCan
 
         public static explicit operator TCAPIVersion(String vStr)
         {
-            var s = GetSupported();
+            var s = GetKnown();
             if (!s.ContainsKey(vStr))
             {
-                throw new ArgumentException("Unsupported version: " + vStr);
+                throw new ArgumentException("Unrecognized version: " + vStr);
             }
 
             return s[vStr];

--- a/TinCanTests/RemoteLRSResourceTest.cs
+++ b/TinCanTests/RemoteLRSResourceTest.cs
@@ -41,9 +41,9 @@ namespace TinCanTests
             // results of the test suite then supply your own endpoint, username, and password
             //
             lrs = new RemoteLRS(
-                "https://cloud.scorm.com/tc/SYPGYC448W/sandbox/",
-                "-DOzXB-DAFR1O3RAazI",
-                "pL-Kyru9fUCFE8981N4"
+                "https://cloud.scorm.com/tc/U2S4SI5FY0/sandbox/",
+                "Nja986GYE1_XrWMmFUE",
+                "Bd9lDr1kjaWWY6RID_4"
             );
         }
 

--- a/TinCanTests/ResultTest.cs
+++ b/TinCanTests/ResultTest.cs
@@ -1,0 +1,70 @@
+﻿/*
+    Copyright 2015 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+namespace TinCanTests
+{
+    using System;
+    using NUnit.Framework;
+    using Newtonsoft.Json.Linq;
+    using TinCan;
+    using TinCan.Json;
+
+    [TestFixture]
+    class ResultTest
+    {
+        [Test]
+        public void TestEmptyCtr()
+        {
+            var obj = new Result();
+            Assert.IsInstanceOf<Result>(obj);
+            Assert.IsNull(obj.completion);
+            Assert.IsNull(obj.success);
+            Assert.IsNull(obj.response);
+            Assert.IsNull(obj.duration);
+            Assert.IsNull(obj.score);
+            Assert.IsNull(obj.extensions);
+
+            StringAssert.AreEqualIgnoringCase("{}", obj.ToJSON());
+        }
+
+        [Test]
+        public void TestJObjectCtr()
+        {
+            var cfg = new JObject();
+            cfg.Add("completion", true);
+            cfg.Add("success", true);
+            cfg.Add("response", "Yes");
+
+            var obj = new Result(cfg);
+            Assert.IsInstanceOf<Result>(obj);
+            Assert.That(obj.completion, Is.EqualTo(true));
+            Assert.That(obj.success, Is.EqualTo(true));
+            Assert.That(obj.response, Is.EqualTo("Yes"));
+        }
+
+        [Test]
+        public void TestStringOfJSONCtr()
+        {
+            var json = "{\"success\": true, \"completion\": true, \"response\": \"Yes\"}";
+            var strOfJson = new StringOfJSON(json);
+
+            var obj = new Result(strOfJson);
+            Assert.IsInstanceOf<Result>(obj);
+            Assert.That(obj.success, Is.EqualTo(true));
+            Assert.That(obj.completion, Is.EqualTo(true));
+            Assert.That(obj.response, Is.EqualTo("Yes"));
+        }
+    }
+}

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AgentTest.cs" />
+    <Compile Include="ResultTest.cs" />
     <Compile Include="Support.cs" />
     <Compile Include="SubStatementTest.cs" />
     <Compile Include="StatementTest.cs" />


### PR DESCRIPTION
All tests pass now (again)! Submitting straight to you Ben since these are pretty straightforward for review. Once merged I'll tag and release a new version with updated AssemblyInfo.