### PR TITLE
Switch to String from Uri for Representing Activity IDs

### DIFF
--- a/TinCan/Activity.cs
+++ b/TinCan/Activity.cs
@@ -24,7 +24,17 @@ namespace TinCan
         public static readonly String OBJECT_TYPE = "Activity";
         public String ObjectType { get { return OBJECT_TYPE; } }
 
-        public Uri id { get; set; }
+        private String _id;
+        public String id
+        {
+            get { return _id; }
+            set
+            {
+                Uri uri = new Uri(value);
+                _id = value;
+            }
+        }
+
         public ActivityDefinition definition { get; set; }
 
         public Activity() { }
@@ -35,7 +45,9 @@ namespace TinCan
         {
             if (jobj["id"] != null)
             {
-                id = new Uri(jobj.Value<String>("id"));
+                String idFromJSON = jobj.Value<String>("id");
+                Uri uri = new Uri(idFromJSON);
+                id = idFromJSON;
             }
             if (jobj["definition"] != null)
             {
@@ -50,7 +62,7 @@ namespace TinCan
 
             if (id != null)
             {
-                result.Add("id", id.ToString());
+                result.Add("id", id);
             }
             if (definition != null)
             {

--- a/TinCan/Activity.cs
+++ b/TinCan/Activity.cs
@@ -24,8 +24,8 @@ namespace TinCan
         public static readonly String OBJECT_TYPE = "Activity";
         public String ObjectType { get { return OBJECT_TYPE; } }
 
-        private String _id;
-        public String id
+        private string _id;
+        public string id
         {
             get { return _id; }
             set
@@ -45,7 +45,7 @@ namespace TinCan
         {
             if (jobj["id"] != null)
             {
-                String idFromJSON = jobj.Value<String>("id");
+                string idFromJSON = jobj.Value<String>("id");
                 Uri uri = new Uri(idFromJSON);
                 id = idFromJSON;
             }

--- a/TinCan/StatementsQuery.cs
+++ b/TinCan/StatementsQuery.cs
@@ -59,7 +59,7 @@ namespace TinCan
             }
             if (activityId != null)
             {
-                result.Add("activity", activityId.ToString());
+                result.Add("activity", activityId);
             }
             if (registration != null)
             {

--- a/TinCan/StatementsQuery.cs
+++ b/TinCan/StatementsQuery.cs
@@ -25,7 +25,15 @@ namespace TinCan
 
         public Agent agent { get; set; }
         public Uri verbId { get; set; }
-        public Uri activityId { get; set; }
+        private String _activityId;
+        public String activityId {
+            get { return _activityId; }
+            set
+            {
+                Uri uri = new Uri(value);
+                _activityId = value;
+            }
+        }
         public Nullable<Guid> registration { get; set; }
         public Nullable<Boolean> relatedActivities { get; set; }
         public Nullable<Boolean> relatedAgents { get; set; }

--- a/TinCan/StatementsQuery.cs
+++ b/TinCan/StatementsQuery.cs
@@ -25,8 +25,8 @@ namespace TinCan
 
         public Agent agent { get; set; }
         public Uri verbId { get; set; }
-        private String _activityId;
-        public String activityId {
+        private string _activityId;
+        public string activityId {
             get { return _activityId; }
             set
             {

--- a/TinCanTests/ActivityTest.cs
+++ b/TinCanTests/ActivityTest.cs
@@ -1,0 +1,51 @@
+﻿/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+namespace TinCanTests
+{
+    using NUnit.Framework;
+    using TinCan;
+
+    [TestFixture]
+    class ActivityTest
+    {
+        [Test]
+        public void TestActivityIdTrailingSlash()
+        {
+            var activity = new Activity();
+            string noTrailingSlash = "http://foo";
+            activity.id = noTrailingSlash;
+            Assert.AreEqual(noTrailingSlash, activity.id);
+        }
+
+
+        [Test]
+        public void TestActivityIdCase()
+        {
+            var activity = new Activity();
+            string mixedCase = "http://fOO";
+            activity.id = mixedCase;
+            Assert.AreEqual(mixedCase, activity.id);
+        }
+
+        [Test]
+        public void TestActivityIdInvalidUri()
+        {
+            var activity = new Activity();
+            string invalid = "foo";
+            activity.id = invalid;
+        }
+    }
+}

--- a/TinCanTests/ActivityTest.cs
+++ b/TinCanTests/ActivityTest.cs
@@ -30,7 +30,6 @@ namespace TinCanTests
             Assert.AreEqual(noTrailingSlash, activity.id);
         }
 
-
         [Test]
         public void TestActivityIdCase()
         {
@@ -41,6 +40,7 @@ namespace TinCanTests
         }
 
         [Test]
+        [ExpectedException("System.UriFormatException")]
         public void TestActivityIdInvalidUri()
         {
             var activity = new Activity();

--- a/TinCanTests/Support.cs
+++ b/TinCanTests/Support.cs
@@ -40,7 +40,7 @@ namespace TinCanTests
             verb.display.Add("en-US", "experienced");
 
             activity = new Activity();
-            activity.id = new Uri("http://tincanapi.com/TinCanCSharp/Test/Unit/0");
+            activity.id = "http://tincanapi.com/TinCanCSharp/Test/Unit/0";
             activity.definition = new ActivityDefinition();
             activity.definition.type = new Uri("http://id.tincanapi.com/activitytype/unit-test");
             activity.definition.name = new LanguageMap();
@@ -49,7 +49,7 @@ namespace TinCanTests
             activity.definition.description.Add("en-US", "Unit test 0 in the test suite for the Tin Can C# library.");
 
             parent = new Activity();
-            parent.id = new Uri("http://tincanapi.com/TinCanCSharp/Test");
+            parent.id = "http://tincanapi.com/TinCanCSharp/Test";
             parent.definition = new ActivityDefinition();
             parent.definition.type = new Uri("http://id.tincanapi.com/activitytype/unit-test-suite");
             //parent.definition.moreInfo = new Uri("http://rusticisoftware.github.io/TinCanCSharp/");

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -71,6 +71,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActivityTest.cs" />
     <Compile Include="AgentTest.cs" />
     <Compile Include="ResultTest.cs" />
     <Compile Include="Support.cs" />


### PR DESCRIPTION
Because of how the xAPI spec handles Activity ID comparision, we can't rely on .NET's `System.Uri`, which normalizes URIs passed to the string constructor.

So, e.g., "http://foo" would become "http://foo/", which is considered a different Activity ID.

Instead, we now use `String` as a representation of Activity IDs, preferring only to validate via `Uri`.