### PR TITLE
Bump Json.NET and NUnit dependencies

### DIFF
--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -41,8 +41,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TinCan/packages.config
+++ b/TinCan/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
 </packages>

--- a/TinCanTests/ActivityTest.cs
+++ b/TinCanTests/ActivityTest.cs
@@ -40,12 +40,16 @@ namespace TinCanTests
         }
 
         [Test]
-        [ExpectedException("System.UriFormatException")]
         public void TestActivityIdInvalidUri()
         {
-            var activity = new Activity();
-            string invalid = "foo";
-            activity.id = invalid;
+            Assert.Throws<System.UriFormatException>(
+                () =>
+                {
+                    var activity = new Activity();
+                    string invalid = "foo";
+                    activity.id = invalid;
+                }
+            );
         }
     }
 }

--- a/TinCanTests/README.md
+++ b/TinCanTests/README.md
@@ -1,0 +1,1 @@
+These tests are based on NUnit 3 which requires that you have a compatible test adapter to run them. For Visual Studio 2012+ you can install the "NUnit3 Test Adapter" available by going to "Tools" -> "Extensions and Updates" -> "Online" -> "Visual Studio Gallery" and searching for "nunit".

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -44,28 +44,13 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.core">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.core.interfaces">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.util">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NUnit.VisualStudio.TestAdapter">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net20\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/TinCanTests/packages.config
+++ b/TinCanTests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net35" />
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
+  <package id="NUnit" version="3.2.0" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
* Remove NUnit test adapter from nuget dependencies as the 2.x version is
  not compatible and 3.x is intended to be run with an adapter installed
  through other means (see new readme)
* Correct a failing unit test not compatible with 3.x

Replaces #21 since the deps have increased again since then and this has a slightly different unit test format.