### PR TITLE
Refactor to use async methods for network calls

### DIFF
--- a/TinCan/ILRS.cs
+++ b/TinCan/ILRS.cs
@@ -15,6 +15,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TinCan.Documents;
 using TinCan.LRSResponses;
 
@@ -22,30 +23,30 @@ namespace TinCan
 {
     public interface ILRS
     {
-        AboutLRSResponse About();
+        Task<AboutLRSResponse> About();
 
-        StatementLRSResponse SaveStatement(Statement statement);
-        StatementLRSResponse VoidStatement(Guid id, Agent agent);
-        StatementsResultLRSResponse SaveStatements(List<Statement> statements);
-        StatementLRSResponse RetrieveStatement(Guid id);
-        StatementLRSResponse RetrieveVoidedStatement(Guid id);
-        StatementsResultLRSResponse QueryStatements(StatementsQuery query);
-        StatementsResultLRSResponse MoreStatements(StatementsResult result);
+        Task<StatementLRSResponse> SaveStatement(Statement statement);
+        Task<StatementLRSResponse> VoidStatement(Guid id, Agent agent);
+        Task<StatementsResultLRSResponse> SaveStatements(List<Statement> statements);
+        Task<StatementLRSResponse> RetrieveStatement(Guid id);
+        Task<StatementLRSResponse> RetrieveVoidedStatement(Guid id);
+        Task<StatementsResultLRSResponse> QueryStatements(StatementsQuery query);
+        Task<StatementsResultLRSResponse> MoreStatements(StatementsResult result);
 
-        ProfileKeysLRSResponse RetrieveStateIds(Activity activity, Agent agent, Nullable<Guid> registration = null);
-        StateLRSResponse RetrieveState(String id, Activity activity, Agent agent, Nullable<Guid> registration = null);
-        LRSResponse SaveState(StateDocument state);
-        LRSResponse DeleteState(StateDocument state);
-        LRSResponse ClearState(Activity activity, Agent agent, Nullable<Guid> registration = null);
+        Task<ProfileKeysLRSResponse> RetrieveStateIds(Activity activity, Agent agent, Nullable<Guid> registration = null);
+        Task<StateLRSResponse> RetrieveState(String id, Activity activity, Agent agent, Nullable<Guid> registration = null);
+        Task<LRSResponse> SaveState(StateDocument state);
+        Task<LRSResponse> DeleteState(StateDocument state);
+        Task<LRSResponse> ClearState(Activity activity, Agent agent, Nullable<Guid> registration = null);
 
-        ProfileKeysLRSResponse RetrieveActivityProfileIds(Activity activity);
-        ActivityProfileLRSResponse RetrieveActivityProfile(String id, Activity activity);
-        LRSResponse SaveActivityProfile(ActivityProfileDocument profile);
-        LRSResponse DeleteActivityProfile(ActivityProfileDocument profile);
+        Task<ProfileKeysLRSResponse> RetrieveActivityProfileIds(Activity activity);
+        Task<ActivityProfileLRSResponse> RetrieveActivityProfile(String id, Activity activity);
+        Task<LRSResponse> SaveActivityProfile(ActivityProfileDocument profile);
+        Task<LRSResponse> DeleteActivityProfile(ActivityProfileDocument profile);
 
-        ProfileKeysLRSResponse RetrieveAgentProfileIds(Agent agent);
-        AgentProfileLRSResponse RetrieveAgentProfile(String id, Agent agent);
-        LRSResponse SaveAgentProfile(AgentProfileDocument profile);
-        LRSResponse DeleteAgentProfile(AgentProfileDocument profile);
+        Task<ProfileKeysLRSResponse> RetrieveAgentProfileIds(Agent agent);
+        Task<AgentProfileLRSResponse> RetrieveAgentProfile(String id, Agent agent);
+        Task<LRSResponse> SaveAgentProfile(AgentProfileDocument profile);
+        Task<LRSResponse> DeleteAgentProfile(AgentProfileDocument profile);
     }
 }

--- a/TinCan/LRSHttpRequest.cs
+++ b/TinCan/LRSHttpRequest.cs
@@ -1,0 +1,75 @@
+﻿/*
+    Copyright 2014-2017 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Text;
+using System.Net.Http;
+
+namespace TinCan
+{
+    /// <summary>
+    /// LRS HTTP request.
+    /// </summary>
+    sealed class LRSHttpRequest
+    {
+        /// <summary>
+        /// Gets or sets the method.
+        /// </summary>
+        /// <value>The method.</value>
+        public HttpMethod Method { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the resource.
+        /// </summary>
+        /// <value>The resource.</value>
+        public string Resource { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the query parameters.
+        /// </summary>
+        /// <value>The query parameters.</value>
+        public Dictionary<string, string> QueryParams { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the headers.
+        /// </summary>
+        /// <value>The headers.</value>
+        public Dictionary<string, string> Headers { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the type of the content.
+        /// </summary>
+        /// <value>The type of the content.</value>
+        public string ContentType { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
+        /// <value>The content.</value>
+        public byte[] Content { get; internal set; }
+
+        /// <summary>
+        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:TinCan.LRSHttpRequest"/>.
+        /// </summary>
+        /// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:TinCan.LRSHttpRequest"/>.</returns>
+        public override string ToString()
+        {
+            return string.Format(
+                "[MyHTTPRequest: method={0}, resource={1}, queryParams={2}, headers={3}, contentType={4}, content={5}]",
+                Method, Resource, string.Join(";", QueryParams), Headers, ContentType, Encoding.UTF8.GetString(Content, 0, Content.Length));
+        }
+    }
+}

--- a/TinCan/LRSHttpResponse.cs
+++ b/TinCan/LRSHttpResponse.cs
@@ -1,0 +1,111 @@
+﻿/*
+    Copyright 2014-2017 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace TinCan
+{
+    /// <summary>
+    /// LRS HTTP response.
+    /// </summary>
+    sealed class LRSHttpResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:TinCan.MyHTTPResponse"/> class.
+        /// </summary>
+        public LRSHttpResponse() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:TinCan.MyHTTPResponse"/> class.
+        /// </summary>
+        /// <param name="response">Web resp.</param>
+        public LRSHttpResponse(HttpResponseMessage response)
+        {
+            if (response == null)
+            {
+                throw new ArgumentNullException(nameof(response));
+            }
+
+            Status = response.StatusCode;
+
+            if (response.Content?.Headers?.ContentType != null)
+            {
+                ContentType = response.Content.Headers.ContentType.ToString();
+            }
+
+            if (response.Headers.ETag != null)
+            {
+                Etag = response.Headers.ETag.ToString();
+            }
+
+            if (response.Content?.Headers?.LastModified != null)
+            {
+                LastModified = response.Content.Headers.LastModified.Value.LocalDateTime;
+            }
+
+            Content = response.Content.ReadAsByteArrayAsync().Result;
+        }
+
+        /// <summary>
+        /// Gets or sets the status.
+        /// </summary>
+        /// <value>The status.</value>
+        public HttpStatusCode Status { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the type of the content.
+        /// </summary>
+        /// <value>The type of the content.</value>
+        public string ContentType { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
+        /// <value>The content.</value>
+        public byte[] Content { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the last modified.
+        /// </summary>
+        /// <value>The last modified.</value>
+        public DateTime LastModified { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the etag.
+        /// </summary>
+        /// <value>The etag.</value>
+        public string Etag { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the ex.
+        /// </summary>
+        /// <value>The ex.</value>
+        public Exception Exception { get; internal set; }
+
+        /// <summary>
+        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:TinCan.LRSHttpResponse"/>.
+        /// </summary>
+        /// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:TinCan.LRSHttpResponse"/>.</returns>
+        public override string ToString()
+        {
+            return string.Format("[MyHTTPResponse: Status={0}, ContentType={1}, Content={2}, LastModified={3}, Etag={4}, Exception={5}]",
+                                 Status, ContentType, Encoding.UTF8.GetString(Content, 0, Content.Length), LastModified, Etag, Exception);
+        }
+    }
+}

--- a/TinCan/TCAPIVersion.cs
+++ b/TinCan/TCAPIVersion.cs
@@ -58,8 +58,8 @@ namespace TinCan
                 return supported;
             }
 
-			supported = new Dictionary<String, TCAPIVersion>();
-			supported.Add("1.0.3", V103);
+            supported = new Dictionary<String, TCAPIVersion>();
+            supported.Add("1.0.3", V103);
             supported.Add("1.0.2", V102);
             supported.Add("1.0.1", V101);
             supported.Add("1.0.0", V100);

--- a/TinCan/TCAPIVersion.cs
+++ b/TinCan/TCAPIVersion.cs
@@ -20,6 +20,7 @@ namespace TinCan
 {
     public sealed class TCAPIVersion
     {
+        public static readonly TCAPIVersion V103 = new TCAPIVersion("1.0.3");
         public static readonly TCAPIVersion V102 = new TCAPIVersion("1.0.2");
         public static readonly TCAPIVersion V101 = new TCAPIVersion("1.0.1");
         public static readonly TCAPIVersion V100 = new TCAPIVersion("1.0.0");
@@ -41,6 +42,7 @@ namespace TinCan
             }
 
             known = new Dictionary<String, TCAPIVersion>();
+            known.Add("1.0.3", V103);
             known.Add("1.0.2", V102);
             known.Add("1.0.1", V101);
             known.Add("1.0.0", V100);
@@ -56,7 +58,8 @@ namespace TinCan
                 return supported;
             }
 
-            supported = new Dictionary<String, TCAPIVersion>();
+			supported = new Dictionary<String, TCAPIVersion>();
+			supported.Add("1.0.3", V103);
             supported.Add("1.0.2", V102);
             supported.Add("1.0.1", V101);
             supported.Add("1.0.0", V100);

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -9,8 +9,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TinCan</RootNamespace>
     <AssemblyName>TinCan</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,10 +41,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
@@ -52,6 +48,11 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="About.cs" />
@@ -94,6 +95,8 @@
     <Compile Include="Verb.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TCAPIVersion.cs" />
+    <Compile Include="LRSHttpRequest.cs" />
+    <Compile Include="LRSHttpResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/TinCan/packages.config
+++ b/TinCan/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>

--- a/TinCanTests/RemoteLRSResourceTest.cs
+++ b/TinCanTests/RemoteLRSResourceTest.cs
@@ -17,6 +17,7 @@ namespace TinCanTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using System.Xml;
     using NUnit.Framework;
     using Newtonsoft.Json.Linq;
@@ -48,38 +49,38 @@ namespace TinCanTests
         }
 
         [Test]
-        public void TestAbout()
+        public async Task TestAbout()
         {
-            AboutLRSResponse lrsRes = lrs.About();
+            AboutLRSResponse lrsRes = await lrs.About();
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestAboutFailure()
+        public async Task TestAboutFailure()
         {
             lrs.endpoint = new Uri("http://cloud.scorm.com/tc/3TQLAI9/sandbox/");
 
-            AboutLRSResponse lrsRes = lrs.About();
+            AboutLRSResponse lrsRes = await lrs.About();
             Assert.IsFalse(lrsRes.success);
             Console.WriteLine("TestAboutFailure - errMsg: " + lrsRes.errMsg);
         }
 
         [Test]
-        public void TestSaveStatement()
+        public async Task TestSaveStatement()
         {
             var statement = new Statement();
             statement.actor = Support.agent;
             statement.verb = Support.verb;
             statement.target = Support.activity;
 
-            StatementLRSResponse lrsRes = lrs.SaveStatement(statement);
+            StatementLRSResponse lrsRes = await lrs.SaveStatement(statement);
             Assert.IsTrue(lrsRes.success);
             Assert.AreEqual(statement, lrsRes.content);
             Assert.IsNotNull(lrsRes.content.id);
         }
 
         [Test]
-        public void TestSaveStatementWithID()
+        public async Task TestSaveStatementWithID()
         {
             var statement = new Statement();
             statement.Stamp();
@@ -87,13 +88,13 @@ namespace TinCanTests
             statement.verb = Support.verb;
             statement.target = Support.activity;
 
-            StatementLRSResponse lrsRes = lrs.SaveStatement(statement);
+            StatementLRSResponse lrsRes = await lrs.SaveStatement(statement);
             Assert.IsTrue(lrsRes.success);
             Assert.AreEqual(statement, lrsRes.content);
         }
 
         [Test]
-        public void TestSaveStatementStatementRef()
+        public async Task TestSaveStatementStatementRef()
         {
             var statement = new Statement();
             statement.Stamp();
@@ -101,13 +102,13 @@ namespace TinCanTests
             statement.verb = Support.verb;
             statement.target = Support.statementRef;
 
-            StatementLRSResponse lrsRes = lrs.SaveStatement(statement);
+            StatementLRSResponse lrsRes = await lrs.SaveStatement(statement);
             Assert.IsTrue(lrsRes.success);
             Assert.AreEqual(statement, lrsRes.content);
         }
 
         [Test]
-        public void TestSaveStatementSubStatement()
+        public async Task TestSaveStatementSubStatement()
         {
             var statement = new Statement();
             statement.Stamp();
@@ -117,24 +118,24 @@ namespace TinCanTests
 
             Console.WriteLine(statement.ToJSON(true));
 
-            StatementLRSResponse lrsRes = lrs.SaveStatement(statement);
+            StatementLRSResponse lrsRes = await lrs.SaveStatement(statement);
             Assert.IsTrue(lrsRes.success);
             Assert.AreEqual(statement, lrsRes.content);
         }
 
         [Test]
-        public void TestVoidStatement()
+        public async Task TestVoidStatement()
         {
             Guid toVoid = Guid.NewGuid();
-            StatementLRSResponse lrsRes = lrs.VoidStatement(toVoid, Support.agent);
+            StatementLRSResponse lrsRes = await lrs.VoidStatement(toVoid, Support.agent);
 
             Assert.IsTrue(lrsRes.success, "LRS response successful");
             Assert.AreEqual(new Uri("http://adlnet.gov/expapi/verbs/voided"), lrsRes.content.verb.id, "voiding statement uses voided verb");
-            Assert.AreEqual(toVoid, ((StatementRef) lrsRes.content.target).id, "voiding statement target correct id");
+            Assert.AreEqual(toVoid, ((StatementRef)lrsRes.content.target).id, "voiding statement target correct id");
         }
 
         [Test]
-        public void TestSaveStatements()
+        public async Task TestSaveStatements()
         {
             var statement1 = new Statement();
             statement1.actor = Support.agent;
@@ -151,13 +152,13 @@ namespace TinCanTests
             statements.Add(statement1);
             statements.Add(statement2);
 
-            StatementsResultLRSResponse lrsRes = lrs.SaveStatements(statements);
+            StatementsResultLRSResponse lrsRes = await lrs.SaveStatements(statements);
             Assert.IsTrue(lrsRes.success);
             // TODO: check statements match and ids not null
         }
 
         [Test]
-        public void TestRetrieveStatement()
+        public async Task TestRetrieveStatement()
         {
             var statement = new TinCan.Statement();
             statement.Stamp();
@@ -167,10 +168,10 @@ namespace TinCanTests
             statement.context = Support.context;
             statement.result = Support.result;
 
-            StatementLRSResponse saveRes = lrs.SaveStatement(statement);
+            StatementLRSResponse saveRes = await lrs.SaveStatement(statement);
             if (saveRes.success)
             {
-                StatementLRSResponse retRes = lrs.RetrieveStatement(saveRes.content.id.Value);
+                StatementLRSResponse retRes = await lrs.RetrieveStatement(saveRes.content.id.Value);
                 Assert.IsTrue(retRes.success);
                 Console.WriteLine("TestRetrieveStatement - statement: " + retRes.content.ToJSON(true));
             }
@@ -181,7 +182,7 @@ namespace TinCanTests
         }
 
         [Test]
-        public void TestQueryStatements()
+        public async Task TestQueryStatements()
         {
             var query = new TinCan.StatementsQuery();
             query.agent = Support.agent;
@@ -192,22 +193,22 @@ namespace TinCanTests
             query.format = StatementsQueryResultFormat.IDS;
             query.limit = 10;
 
-            StatementsResultLRSResponse lrsRes = lrs.QueryStatements(query);
+            StatementsResultLRSResponse lrsRes = await lrs.QueryStatements(query);
             Assert.IsTrue(lrsRes.success);
             Console.WriteLine("TestQueryStatements - statement count: " + lrsRes.content.statements.Count);
         }
 
         [Test]
-        public void TestMoreStatements()
+        public async Task TestMoreStatements()
         {
             var query = new TinCan.StatementsQuery();
             query.format = StatementsQueryResultFormat.IDS;
             query.limit = 2;
 
-            StatementsResultLRSResponse queryRes = lrs.QueryStatements(query);
+            StatementsResultLRSResponse queryRes = await lrs.QueryStatements(query);
             if (queryRes.success && queryRes.content.more != null)
             {
-                StatementsResultLRSResponse moreRes = lrs.MoreStatements(queryRes.content);
+                StatementsResultLRSResponse moreRes = await lrs.MoreStatements(queryRes.content);
                 Assert.IsTrue(moreRes.success);
                 Console.WriteLine("TestMoreStatements - statement count: " + moreRes.content.statements.Count);
             }
@@ -218,22 +219,22 @@ namespace TinCanTests
         }
 
         [Test]
-        public void TestRetrieveStateIds()
+        public async Task TestRetrieveStateIds()
         {
-            ProfileKeysLRSResponse lrsRes = lrs.RetrieveStateIds(Support.activity, Support.agent);
+            ProfileKeysLRSResponse lrsRes = await lrs.RetrieveStateIds(Support.activity, Support.agent);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestRetrieveState()
+        public async Task TestRetrieveState()
         {
-            StateLRSResponse lrsRes = lrs.RetrieveState("test", Support.activity, Support.agent);
+            StateLRSResponse lrsRes = await lrs.RetrieveState("test", Support.activity, Support.agent);
             Assert.IsTrue(lrsRes.success);
             Assert.IsInstanceOf<TinCan.Documents.StateDocument>(lrsRes.content);
         }
 
         [Test]
-        public void TestSaveState()
+        public async Task TestSaveState()
         {
             var doc = new StateDocument();
             doc.activity = Support.activity;
@@ -241,102 +242,102 @@ namespace TinCanTests
             doc.id = "test";
             doc.content = System.Text.Encoding.UTF8.GetBytes("Test value");
 
-            LRSResponse lrsRes = lrs.SaveState(doc);
+            LRSResponse lrsRes = await lrs.SaveState(doc);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestDeleteState()
+        public async Task TestDeleteState()
         {
             var doc = new StateDocument();
             doc.activity = Support.activity;
             doc.agent = Support.agent;
             doc.id = "test";
 
-            LRSResponse lrsRes = lrs.DeleteState(doc);
+            LRSResponse lrsRes = await lrs.DeleteState(doc);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestClearState()
+        public async Task TestClearState()
         {
-            LRSResponse lrsRes = lrs.ClearState(Support.activity, Support.agent);
+            LRSResponse lrsRes = await lrs.ClearState(Support.activity, Support.agent);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestRetrieveActivityProfileIds()
+        public async Task TestRetrieveActivityProfileIds()
         {
-            ProfileKeysLRSResponse lrsRes = lrs.RetrieveActivityProfileIds(Support.activity);
+            ProfileKeysLRSResponse lrsRes = await lrs.RetrieveActivityProfileIds(Support.activity);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestRetrieveActivityProfile()
+        public async Task TestRetrieveActivityProfile()
         {
-            ActivityProfileLRSResponse lrsRes = lrs.RetrieveActivityProfile("test", Support.activity);
+            ActivityProfileLRSResponse lrsRes = await lrs.RetrieveActivityProfile("test", Support.activity);
             Assert.IsTrue(lrsRes.success);
             Assert.IsInstanceOf<TinCan.Documents.ActivityProfileDocument>(lrsRes.content);
         }
 
         [Test]
-        public void TestSaveActivityProfile()
+        public async Task TestSaveActivityProfile()
         {
             var doc = new ActivityProfileDocument();
             doc.activity = Support.activity;
             doc.id = "test";
             doc.content = System.Text.Encoding.UTF8.GetBytes("Test value");
 
-            LRSResponse lrsRes = lrs.SaveActivityProfile(doc);
+            LRSResponse lrsRes = await lrs.SaveActivityProfile(doc);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestDeleteActivityProfile()
+        public async Task TestDeleteActivityProfile()
         {
             var doc = new ActivityProfileDocument();
             doc.activity = Support.activity;
             doc.id = "test";
 
-            LRSResponse lrsRes = lrs.DeleteActivityProfile(doc);
+            LRSResponse lrsRes = await lrs.DeleteActivityProfile(doc);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestRetrieveAgentProfileIds()
+        public async Task TestRetrieveAgentProfileIds()
         {
-            ProfileKeysLRSResponse lrsRes = lrs.RetrieveAgentProfileIds(Support.agent);
+            ProfileKeysLRSResponse lrsRes = await lrs.RetrieveAgentProfileIds(Support.agent);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestRetrieveAgentProfile()
+        public async Task TestRetrieveAgentProfile()
         {
-            AgentProfileLRSResponse lrsRes = lrs.RetrieveAgentProfile("test", Support.agent);
+            AgentProfileLRSResponse lrsRes = await lrs.RetrieveAgentProfile("test", Support.agent);
             Assert.IsTrue(lrsRes.success);
             Assert.IsInstanceOf<TinCan.Documents.AgentProfileDocument>(lrsRes.content);
         }
 
         [Test]
-        public void TestSaveAgentProfile()
+        public async Task TestSaveAgentProfile()
         {
             var doc = new AgentProfileDocument();
             doc.agent = Support.agent;
             doc.id = "test";
             doc.content = System.Text.Encoding.UTF8.GetBytes("Test value");
 
-            LRSResponse lrsRes = lrs.SaveAgentProfile(doc);
+            LRSResponse lrsRes = await lrs.SaveAgentProfile(doc);
             Assert.IsTrue(lrsRes.success);
         }
 
         [Test]
-        public void TestDeleteAgentProfile()
+        public async Task TestDeleteAgentProfile()
         {
             var doc = new AgentProfileDocument();
             doc.agent = Support.agent;
             doc.id = "test";
 
-            LRSResponse lrsRes = lrs.DeleteAgentProfile(doc);
+            LRSResponse lrsRes = await lrs.DeleteAgentProfile(doc);
             Assert.IsTrue(lrsRes.success);
         }
     }

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -9,8 +9,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TinCanTests</RootNamespace>
     <AssemblyName>TinCanTests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -44,16 +44,14 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.0\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivityTest.cs" />

--- a/TinCanTests/packages.config
+++ b/TinCanTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net35" />
-  <package id="NUnit" version="3.2.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This change makes all of the public methods in `ILRS` return `Task` objects, and implements these as `async` methods in `RemoteLRS`. Some related changes:

* `MyHTTPRequest` and `MyHTTPResponse` have been moved to `LRSHttpRequest` and `LRSHttpResponse`
* `HttpClient` is used instead of `HttpWebRequest` for better `async` support, and so that this library can be used as a PCL, as `HttpWebRequest` is not part of the .NET Portable Subset.
* The .NET Framework version has been updated to 4.5 (`async` only requires 4.0, but `HttpClient` requires 4.5).
* NUnit has been updated to 3.6.1 to support `async` tests.
* xAPI v1.0.3 has been added to `TCAPIVersion` to allow unit tests to pass.

This is the first in a series of pull requests, as we made a number of changes to this library at @gowithfloat for a recent project, and would like to integrate them back into the core library. Some of these changes will be breaking (like this one).

I know there's [another pull request](https://github.com/RusticiSoftware/TinCan.NET/pull/18) that _adds_ `async` version of methods, but as these are all network calls, they should be refactored to only be `async`. There's also a [related issue](https://github.com/RusticiSoftware/TinCan.NET/issues/13) currently open.

Please let me know if you have any questions or comments. Thanks!