### PR TITLE
Multiple framework targets and signed version in nuget package

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ Release-net40
 Release-net45
 Release-net45-signed
 
-The click "Build" to build the selected configurations. (Verify `bin/Release/net<X>/TinCan.dll` has correct version.)
+Then click "Build" to build the selected configurations. (Verify `bin/Release/net<X>/TinCan.dll` has correct version.)
 
 With `nuget.exe` installed and in your path do:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,12 +2,22 @@ Make sure that the `TinCan/Properties/AssemblyInfo.cs` has been updated with new
 
     TinCan -> Properties -> Assembly Information
 
-Then set the Build Configuration to "Release" and build the solution. (Verify `bin/Release/TinCan.dll` has correct version.)
+Obtain the `TinCan.NET.pfx` file that is used for signing the relevant portions of the release.
+
+Then right-click the solution in the "Solution Explorer" view and select "Batch Build...". Check the "Build" checkbox for the following `TinCan` configurations:
+Release-net35
+Release-net40
+Release-net45
+Release-net45-signed
+
+The click "Build" to build the selected configurations. (Verify `bin/Release/net<X>/TinCan.dll` has correct version.)
 
 With `nuget.exe` installed and in your path do:
 
     cd TinCan
-    nuget pack TinCan.csproj -sym -Prop Configuration=Release
+    nuget pack TinCan.csproj -sym -Prop Configuration=Release-net35
     nuget push TinCan.(version).nupkg
+
+Note: Providing a `Configuration` property is mandatory, otherwise `nuget` will build the `Debug` configuration and include that in the package. The `<files>` portion of the `.nuspec` ensures all releases built previously are in the created `nuget` package.
 
 Commit the updated assembly information file and push to master. Upload the generated `TinCan.(version).nupkg` as a GitHub tag release.

--- a/TinCan.sln
+++ b/TinCan.sln
@@ -12,6 +12,8 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Documentation|Any CPU = Documentation|Any CPU
 		Release-net35|Any CPU = Release-net35|Any CPU
+		Release-net40|Any CPU = Release-net40|Any CPU
+		Release-net45|Any CPU = Release-net45|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -20,16 +22,26 @@ Global
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Documentation|Any CPU.Build.0 = Documentation|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net40|Any CPU.ActiveCfg = Release-net40|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net40|Any CPU.Build.0 = Release-net40|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45|Any CPU.ActiveCfg = Release-net45|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45|Any CPU.Build.0 = Release-net45|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net40|Any CPU.ActiveCfg = Release-net40|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net40|Any CPU.Build.0 = Release-net40|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45|Any CPU.ActiveCfg = Release-net45|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45|Any CPU.Build.0 = Release-net45|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.Build.0 = Documentation|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
+		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net40|Any CPU.ActiveCfg = Release-net35|Any CPU
+		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net45|Any CPU.ActiveCfg = Release-net35|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TinCan.sln
+++ b/TinCan.sln
@@ -11,25 +11,25 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Documentation|Any CPU = Documentation|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Release-net35|Any CPU = Release-net35|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Documentation|Any CPU.Build.0 = Documentation|Any CPU
-		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
-		{854413C2-2F81-4A82-9949-DE2868A10078}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{854413C2-2F81-4A82-9949-DE2868A10078}.Release|Any CPU.Build.0 = Release|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.Build.0 = Documentation|Any CPU
-		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net35|Any CPU.ActiveCfg = Release-net35|Any CPU
+		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TinCan.sln
+++ b/TinCan.sln
@@ -14,6 +14,7 @@ Global
 		Release-net35|Any CPU = Release-net35|Any CPU
 		Release-net40|Any CPU = Release-net40|Any CPU
 		Release-net45|Any CPU = Release-net45|Any CPU
+		Release-net45-signed|Any CPU = Release-net45-signed|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -26,6 +27,8 @@ Global
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net40|Any CPU.Build.0 = Release-net40|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45|Any CPU.ActiveCfg = Release-net45|Any CPU
 		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45|Any CPU.Build.0 = Release-net45|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45-signed|Any CPU.ActiveCfg = Release-net45-signed|Any CPU
+		{27D0FCA1-E869-440C-9D16-F62D7A068C53}.Release-net45-signed|Any CPU.Build.0 = Release-net45-signed|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
@@ -35,6 +38,8 @@ Global
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net40|Any CPU.Build.0 = Release-net40|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45|Any CPU.ActiveCfg = Release-net45|Any CPU
 		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45|Any CPU.Build.0 = Release-net45|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45-signed|Any CPU.ActiveCfg = Release-net45-signed|Any CPU
+		{854413C2-2F81-4A82-9949-DE2868A10078}.Release-net45-signed|Any CPU.Build.0 = Release-net45-signed|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.ActiveCfg = Documentation|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Documentation|Any CPU.Build.0 = Documentation|Any CPU
@@ -42,6 +47,7 @@ Global
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net35|Any CPU.Build.0 = Release-net35|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net40|Any CPU.ActiveCfg = Release-net35|Any CPU
 		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net45|Any CPU.ActiveCfg = Release-net35|Any CPU
+		{F8D803AD-A192-4F8C-A582-674B75E42995}.Release-net45-signed|Any CPU.ActiveCfg = Release-net35|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Documentation|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -48,6 +49,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
     <OutputPath>bin\Release\net45\</OutputPath>

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-net35|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Release\net35\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -41,7 +41,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net40|AnyCPU'">
-    <OutputPath>bin\Release-net40\</OutputPath>
+    <OutputPath>bin\Release\net40\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -50,7 +50,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
-    <OutputPath>bin\Release-net45\</OutputPath>
+    <OutputPath>bin\Release\net45\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -51,6 +51,25 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
     <OutputPath>bin\Release\net45\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45-signed|AnyCPU'">
+    <OutputPath>bin\Release\net45-signed</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>TinCan.NET.pfx</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -109,6 +128,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="TinCan.NET.pfx" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -22,7 +22,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\TinCan.XML</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-net35|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/TinCan/TinCan.csproj
+++ b/TinCan/TinCan.csproj
@@ -40,6 +40,18 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net40|AnyCPU'">
+    <OutputPath>bin\Release-net40\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
+    <OutputPath>bin\Release-net45\</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>

--- a/TinCan/TinCan.nuspec
+++ b/TinCan/TinCan.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-      <file src="bin\Release\**" target="lib" />
+      <file src="bin\Release\**\TinCan*" target="lib" />
   </files>
 </package>

--- a/TinCan/TinCan.nuspec
+++ b/TinCan/TinCan.nuspec
@@ -18,4 +18,7 @@
       <dependency id="Newtonsoft.Json" version="8.0" />
     </dependencies>
   </metadata>
+  <files>
+      <file src="bin\Release\**" target="lib" />
+  </files>
 </package>

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-net35|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -43,6 +43,18 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net40|AnyCPU'">
+    <OutputPath>bin\Release-net40\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
+    <OutputPath>bin\Release-net45\</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -54,6 +54,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
     <OutputPath>bin\Release-net45\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45-signed|AnyCPU'">
     <OutputPath>bin\Release-net45-signed\</OutputPath>

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -55,6 +55,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
     <OutputPath>bin\Release-net45\</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45-signed|AnyCPU'">
+    <OutputPath>bin\Release-net45-signed\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>

--- a/TinCanTests/TinCanTests.csproj
+++ b/TinCanTests/TinCanTests.csproj
@@ -51,6 +51,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
     <OutputPath>bin\Release-net45\</OutputPath>
@@ -60,6 +61,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45-signed|AnyCPU'">
     <OutputPath>bin\Release-net45-signed\</OutputPath>
@@ -69,6 +71,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
Changes:
Set nuget to be "embedded" in project in a similar fashion to our other projects. This means dependencies will be pulled down on build without having to do anything in Visual Studio. (All the nuget files are automatically added by VS)

Renamed "Release" configuration to "Release-net35" and added further configs for net40, net45 and net45-signed.

Set Newtonsoft dll to NOT be "Copy Local" (`<Private>False</Private>`) so that it doesn't end up in the .nupkg with the changes to `.nuspec`.

Added new ant `build.xml` to build and package the `.nupkg`. Makes it a bit easier for now (saves manually selecting the config in VS and rebuilding a bunch of time) and will be useful if we ever move to building this on build server.