### PR TITLE
Add the params in extended to the request URL

### DIFF
--- a/TinCan/RemoteLRS.cs
+++ b/TinCan/RemoteLRS.cs
@@ -22,6 +22,7 @@ using System.Web;
 using Newtonsoft.Json.Linq;
 using TinCan.Documents;
 using TinCan.LRSResponses;
+using System.Linq;
 
 namespace TinCan
 {
@@ -81,7 +82,7 @@ namespace TinCan
             }
         }
 
-        private string AppendParamsToExistingQueryString(string currentQueryString, Dictionary<string, string> parameters)
+        private string AppendParamsToExistingQueryString(string currentQueryString,  IEnumerable<KeyValuePair<string,  string>> parameters)
         {
             foreach (KeyValuePair<String, String> entry in parameters)
             {
@@ -113,7 +114,7 @@ namespace TinCan
 
             String qs = "";
             qs = AppendParamsToExistingQueryString(qs, req.queryParams);
-            qs = AppendParamsToExistingQueryString(qs, extended);
+            qs = AppendParamsToExistingQueryString(qs, extended.Where(w => !req.queryParams.ContainsKey(w.Key)));
 
             if (qs != "")
             {

--- a/TinCan/RemoteLRS.cs
+++ b/TinCan/RemoteLRS.cs
@@ -81,6 +81,20 @@ namespace TinCan
             }
         }
 
+        private string AppendParamsToExistingQueryString(string currentQueryString, Dictionary<string, string> parameters)
+        {
+            foreach (KeyValuePair<String, String> entry in parameters)
+            {
+                if (currentQueryString != "")
+                {
+                    currentQueryString += "&";
+                }
+                currentQueryString += HttpUtility.UrlEncode(entry.Key) + "=" + HttpUtility.UrlEncode(entry.Value);
+            }
+
+            return currentQueryString;
+        }
+
         private MyHTTPResponse MakeSyncRequest(MyHTTPRequest req)
         {
             String url;
@@ -97,21 +111,13 @@ namespace TinCan
                 url += req.resource;
             }
 
-            if (req.queryParams != null)
+            String qs = "";
+            qs = AppendParamsToExistingQueryString(qs, req.queryParams);
+            qs = AppendParamsToExistingQueryString(qs, extended);
+
+            if (qs != "")
             {
-                String qs = "";
-                foreach (KeyValuePair<String, String> entry in req.queryParams)
-                {
-                    if (qs != "")
-                    {
-                        qs += "&";
-                    }
-                    qs += HttpUtility.UrlEncode(entry.Key) + "=" + HttpUtility.UrlEncode(entry.Value);
-                }
-                if (qs != "")
-                {
-                    url += "?" + qs;
-                }
+                url += "?" + qs;
             }
 
             // TODO: handle special properties we recognize, such as content type, modified since, etc.
@@ -123,13 +129,11 @@ namespace TinCan
             {
                 webReq.Headers.Add("Authorization", auth);
             }
-            if (req.headers != null)
+            foreach (KeyValuePair<String, String> entry in req.headers)
             {
-                foreach (KeyValuePair<String, String> entry in req.headers)
-                {
-                    webReq.Headers.Add(entry.Key, entry.Value);
-                }
+                webReq.Headers.Add(entry.Key, entry.Value);
             }
+            
 
             if (req.contentType != null)
             {

--- a/TinCan/RemoteLRS.cs
+++ b/TinCan/RemoteLRS.cs
@@ -30,7 +30,7 @@ namespace TinCan
         public Uri endpoint { get; set; }
         public TCAPIVersion version { get; set; }
         public String auth { get; set; }
-        public Dictionary<String, String> extended { get; set; }
+        public Dictionary<String, String> extended { get; set; } = new Dictionary<String, String>();
 
         public void SetAuth(String username, String password)
         {
@@ -51,8 +51,8 @@ namespace TinCan
         {
             public String method { get; set; }
             public String resource { get; set; }
-            public Dictionary<String, String> queryParams { get; set; }
-            public Dictionary<String, String> headers { get; set; }
+            public Dictionary<String, String> queryParams { get; set; } = new Dictionary<String, String>();
+            public Dictionary<String, String> headers { get; set; } = new Dictionary<String, String>();
             public String contentType { get; set; }
             public byte[] content { get; set; }
         }

--- a/TinCanTests/RemoteLRSResourceTest.cs
+++ b/TinCanTests/RemoteLRSResourceTest.cs
@@ -339,5 +339,23 @@ namespace TinCanTests
             LRSResponse lrsRes = lrs.DeleteAgentProfile(doc);
             Assert.IsTrue(lrsRes.success);
         }
+
+        [Test]
+        public void TestExtendedParameters()
+        {
+            // RemoteLRS doesn't provide a helpful interface for testing
+            // that we successfully altered the request URL, but this test
+            // is helpful in manual testing and it at least ensures that
+            // specifying values in extended doesn't cause errors.
+            lrs.extended.Add("test", "param");
+            var doc = new StateDocument();
+            doc.activity = Support.activity;
+            doc.agent = Support.agent;
+            doc.id = "test";
+            doc.content = System.Text.Encoding.UTF8.GetBytes("Test value");
+
+            LRSResponse lrsRes = lrs.SaveState(doc);
+            Assert.IsTrue(lrsRes.success);
+        }
     }
 }


### PR DESCRIPTION
`extended` was already a property on `RemoteLRS` with this intent, but it wasn't implemented yet. Now, if you want to append arbitrary parameters to the request URL, you can do so by setting values in the `extended` dictionary.

Also, I added default empty dictionaries to a few properties on `RemoteLRS` as a small usability improvement.