### PR TITLE
Switched to using AbsoluteUri prop for Uri objects

### DIFF
--- a/TinCan/ActivityDefinition.cs
+++ b/TinCan/ActivityDefinition.cs
@@ -119,11 +119,11 @@ namespace TinCan
 
             if (type != null)
             {
-                result.Add("type", type.ToString());
+                result.Add("type", type.AbsoluteUri);
             }
             if (moreInfo != null)
             {
-                result.Add("moreInfo", moreInfo.ToString());
+                result.Add("moreInfo", moreInfo.AbsoluteUri);
             }
             if (name != null && ! name.isEmpty())
             {

--- a/TinCan/AgentAccount.cs
+++ b/TinCan/AgentAccount.cs
@@ -52,7 +52,7 @@ namespace TinCan
             JObject result = new JObject();
             if (homePage != null)
             {
-                result.Add("homePage", homePage.ToString());
+                result.Add("homePage", homePage.AbsoluteUri);
             }
             if (name != null)
             {

--- a/TinCan/RemoteLRS.cs
+++ b/TinCan/RemoteLRS.cs
@@ -105,7 +105,7 @@ namespace TinCan
             }
             else
             {
-                url = endpoint.ToString();
+                url = endpoint.AbsoluteUri;
                 if (! url.EndsWith("/") && ! req.resource.StartsWith("/")) {
                     url += "/";
                 }

--- a/TinCan/StatementsQuery.cs
+++ b/TinCan/StatementsQuery.cs
@@ -55,7 +55,7 @@ namespace TinCan
             }
             if (verbId != null)
             {
-                result.Add("verb", verbId.ToString());
+                result.Add("verb", verbId.AbsoluteUri);
             }
             if (activityId != null)
             {

--- a/TinCan/Verb.cs
+++ b/TinCan/Verb.cs
@@ -54,7 +54,7 @@ namespace TinCan
             JObject result = new JObject();
             if (id != null)
             {
-                result.Add("id", id.ToString());
+                result.Add("id", id.AbsoluteUri);
             }
 
             if (display != null && ! display.isEmpty())

--- a/TinCanTests/ActivityTest.cs
+++ b/TinCanTests/ActivityTest.cs
@@ -15,6 +15,7 @@
 */
 namespace TinCanTests
 {
+    using System;
     using NUnit.Framework;
     using TinCan;
 
@@ -50,6 +51,24 @@ namespace TinCanTests
                     activity.id = invalid;
                 }
             );
+        }
+
+        [Test]
+        public void TestActivityDefinitionUriSerialization()
+        {
+            var moreInfo = new Uri("mailto:email@adlnet.gov?cc=cc@adlnet.gov&subject=Message%20Subject&body=This%20is%20a%20long%20message");
+            var type = new Uri("http://adlnet.gov/expapi/activities/test/%20with%20space");
+
+            var def = new ActivityDefinition
+            {
+                moreInfo = moreInfo,
+                type = type
+            };
+
+            var json = def.ToJObject(TCAPIVersion.latest());
+
+            Assert.AreEqual("mailto:email@adlnet.gov?cc=cc@adlnet.gov&subject=Message%20Subject&body=This%20is%20a%20long%20message", json["moreInfo"].ToString(), "ActivityDefinition.moreInfo serialization failed to preserve encoding");
+            Assert.AreEqual("http://adlnet.gov/expapi/activities/test/%20with%20space", json["type"].ToString(), "ActivityDefinition.type serialization failed to preserve encoding");
         }
     }
 }

--- a/TinCanTests/AgentTest.cs
+++ b/TinCanTests/AgentTest.cs
@@ -59,5 +59,17 @@ namespace TinCanTests
             Assert.IsInstanceOf<Agent>(obj);
             Assert.That(obj.mbox, Is.EqualTo(mbox));
         }
+
+        [Test]
+        public void TestAgentAccountUriSerialization()
+        {
+            var account = new AgentAccount
+            {
+                homePage = new Uri("http://adlnet.gov/home/%20page")
+            };
+
+            var json = account.ToJObject(TCAPIVersion.latest());
+            Assert.AreEqual("http://adlnet.gov/home/%20page", json["homePage"].ToString(), "AgentAccount.homePage serialization failed to preserve encoding");
+        }
     }
 }

--- a/TinCanTests/StatementTest.cs
+++ b/TinCanTests/StatementTest.cs
@@ -61,5 +61,17 @@ namespace TinCanTests
             Assert.IsInstanceOf<Statement>(obj);
             Assert.IsInstanceOf<SubStatement>(obj.target);
         }
+
+        [Test]
+        public void TestStatementsQueryUriSerialization()
+        {
+            var query = new StatementsQuery
+            {
+                verbId = new Uri("http://adlnet.gov/expapi/verbs/%20test")
+            };
+
+            var paramsMap = query.ToParameterMap(TCAPIVersion.latest());
+            Assert.AreEqual("http://adlnet.gov/expapi/verbs/%20test", paramsMap["verb"], "StatementsQuery.verbId serialization failed to preserve encoding");
+        }
     }
 }

--- a/TinCanTests/VerbTest.cs
+++ b/TinCanTests/VerbTest.cs
@@ -59,5 +59,17 @@ namespace TinCanTests
             Assert.IsInstanceOf<Verb>(obj);
             Assert.That(obj.ToJSON(), Is.EqualTo(json));
         }
+
+        [Test]
+        public void TestVerbUriSerialization()
+        {
+            var verb = new Verb
+            {
+                id = new Uri("http://adlnet.gov/expapi/verbs/%20test")
+            };
+
+            var json = verb.ToJObject(TCAPIVersion.latest());
+            Assert.AreEqual("http://adlnet.gov/expapi/verbs/%20test", json["id"].ToString(), "Verb.id serialization failed to preserve encoding");
+        }
     }
 }


### PR DESCRIPTION
Replaced `Uri.ToString()` with `Uri.AbsoluteUri` in various locations throughout the solution.

[`Uri.ToString()`](https://learn.microsoft.com/en-us/dotnet/api/system.uri.tostring?view=netframework-3.5) intentionally returns an **unescaped canonical representation** of the Uri instance. It is therefore not suitable for transmission across services, I.e. to the LRS.

Using `Uri.ToString()` meant that when setting Uri values that contained encoded cahracters (E.g. spaces), these characters would be sent unencoded, the LRS would then return an error. For example seen from SCORM Cloud: 

>The value 'mailto:email@address.com?cc=cc@test.com&subject=Message Subject&body=This is a long message' specified for MoreInfo property of ActivityDefinition is not an absolute URI

Switching to `Uri.AbsoluteUri` resolves this issue, as encoding is retained, and in the case above the following value is sent instead, which succeeds without error:

`mailto:email@address.com?cc=cc@test.com&subject=Message%20Subject&body=This%20is%20a%20long%20message`

Additional unit tests were added to test this, and existing unit tests all pass.